### PR TITLE
IE bugfix: cannot add css-rules into style-tag

### DIFF
--- a/jquery.injectCSS.js
+++ b/jquery.injectCSS.js
@@ -61,8 +61,6 @@
                                 jsonToCSS(makeSelectorName(scope, property), value);
                             }
                             break;
-                        default:
-                            console.log("ignoring unknown type " + typeof(value) + " in property " + property);
                     }
                 }
             }
@@ -119,7 +117,6 @@
                 eval("var jss = {" + jss + "}");
             }
             catch (e) {
-                console.log(e);
                 return "/*\nUnable to parse JSS: " + e + "\n*/";
             }
         }
@@ -154,7 +151,11 @@
 
         var container = jQuery("#" + options.containerName);
         if (!container.length) {
-            container = jQuery("<style id='" + options.containerName + "' media='" + options.media + "'>").appendTo("head");
+            container = jQuery("<style></style>").appendTo('head').attr({
+                media: options.media,
+                id: options.containerName,
+                type: 'text/css'
+            })[0];
         }
 
         var css = "";
@@ -162,7 +163,13 @@
             css += container.text();
         }
         css += toCSS(jss);
-        container.text(css);
+
+        if (container.styleSheet !== undefined && container.styleSheet.cssText !== undefined) { // IE
+            container.styleSheet.cssText = css;
+        } else {
+            container.appendChild(document.createTextNode(css)); // Others
+        }
+
         return container;
     };
 }(jQuery));


### PR DESCRIPTION
Hello
I found that IE cannot add css-rules into style-tag so I had to find workaround.
I took one of them from here: http://forum.jquery.com/topic/jquery-append-into-style-element-causes-error-in-ie-only#14737000000368311 
