### PR TITLE
Support raw values and given container style node

### DIFF
--- a/jquery.injectCSS.js
+++ b/jquery.injectCSS.js
@@ -141,6 +141,7 @@
 
     var defaults = {
         truncateFirst: false,
+        container: null,
         containerName: "injectCSSContainer",
         useRawValues: false
     };
@@ -150,7 +151,7 @@
 
         options.media = options.media || 'all';
 
-        var container = jQuery("#" + options.containerName);
+        var container = (options.container && jQuery(options.container)) || jQuery("#" + options.containerName);
         if (!container.length) {
             container = jQuery("<style></style>").appendTo('head').attr({
                 media: options.media,


### PR DESCRIPTION
- Raw numbers are useful e.g. in CSS calc
- passing in a container style node allows for scoped styles inside body (http://updates.html5rocks.com/2012/03/A-New-Experimental-Feature-style-scoped)
