### PR TITLE
merge option to avoid growing heap of css rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 jquery-injectCSS
 ================
 
-Allows for injection of CSS defined as javascript JSS objects. 
+Allows for injection of CSS defined as javascript JSS objects.
 
 Based on JSS (http://jss-lang.org/).
 
@@ -47,6 +47,13 @@ See http://jss-lang.org/ for further documenation on the JSS language.
 **truncateFirst** (default=false): Clear all previously set styles in containerName.
 
 **media** (default="all"): Media type.
+
+**merge** (default=false): Merge new css with existing set of rules.
+Existing version of css cached in the memory during previous call of inject method with this option.
+Setting this option to false will clear the cache.
+This option is useful for making changes repeatedly,
+to avoid growing heap of overwritten properties in the head of html document.
+Setting this option to true will also forces truncateFirst option to be true.
 
 ### License
 jquery-injectCSS is free software, and may be redistributed under the MIT-LICENSE.

--- a/jquery.injectCSS.js
+++ b/jquery.injectCSS.js
@@ -120,7 +120,14 @@
                 return "/*\nUnable to parse JSS: " + e + "\n*/";
             }
         }
-
+        if(options.merge)
+        {
+            if(!jQuery.injectCSS.jssCache)
+                jQuery.injectCSS.jssCache = {};
+            jss = jQuery.extend(true, jQuery.injectCSS.jssCache, jss);
+        }else{
+            delete jQuery.injectCSS.jssCache;
+        }
         jsonToCSS("", jss);
 
         // output result:
@@ -139,17 +146,13 @@
         return ret;
     }
 
-    var defaults = {
-        truncateFirst: false,
-        container: null,
-        containerName: "injectCSSContainer",
-        useRawValues: false
-    };
 
     jQuery.injectCSS = function (jss, options) {
-        options = jQuery.extend({}, defaults, options);
+        options = jQuery.extend({}, jQuery.injectCSS.defaults, options);
 
         options.media = options.media || 'all';
+        // in merge mode we also need to truncate first, previous version of css will be restored from the inner cache
+        options.truncateFirst = options.truncateFirst||options.merge;
 
         var container = (options.container && jQuery(options.container)) || jQuery("#" + options.containerName);
         if (!container.length) {
@@ -177,4 +180,14 @@
 
         return container;
     };
+
+    //defaults exposed to allow chage defaults
+    jQuery.injectCSS.defaults = {
+        truncateFirst: false,
+        container: null,
+        containerName: "injectCSSContainer",
+        useRawValues: false,
+        merge:false
+    };
+
 }(jQuery));


### PR DESCRIPTION
Merge option is useful for making changes repeatedly to avoid growing heap of overwritten properties in the head of html document.